### PR TITLE
fix: inscription parsing bug

### DIFF
--- a/substreams/Cargo.toml
+++ b/substreams/Cargo.toml
@@ -19,6 +19,7 @@ substreams-ethereum = "0.9"
 substreams-database-change = "1"
 hex = "0.4.3"
 bitcoin = "0.31.0"
+anyhow = "1"
 
 # Required so that ethabi > ethereum-types build correctly under wasm32-unknown-unknown
 [target.wasm32-unknown-unknown.dependencies]


### PR DESCRIPTION
- Fix bug in inscription parsing that caused certain envelopes to be ignored
- Change inscription parsing to skip transactions in case of parsing errors instead of panicking